### PR TITLE
#165413084 user can track comment edit histories

### DIFF
--- a/src/actions/comment.js
+++ b/src/actions/comment.js
@@ -5,7 +5,8 @@ import {
   DELETE_COMMENT,
   UPDATE_COMMENT,
   LIKE_COMMENT,
-  GET_COMMENT_LIKES
+  GET_COMMENT_LIKES,
+  FETCH_ONE_COMMENT
 } from './types';
 
 export const createComment = (comment, slug) => dispatch => {
@@ -21,7 +22,12 @@ export const fetchComment = slug => dispatch => {
     payload: http.get(`/api/v1/article/${slug}/comments`)
   });
 };
-
+export const fetchOneComment = (slug, id) => dispatch => {
+  dispatch({
+    type: FETCH_ONE_COMMENT,
+    payload: http.get(`/api/v1/article/${slug}/comments/${ id }`)
+  });
+};
 export const deleteComment = (id, slug) => dispatch => {
   dispatch({
     type: DELETE_COMMENT,

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -21,6 +21,7 @@ export const ONE_STORY = 'ONE_STORY';
 export const DELETE_STORY = 'DELETE_STORY';
 export const CREATE_COMMENT = 'CREATE_COMMENT';
 export const FETCH_COMMENT = 'FETCH_COMMENT';
+export const FETCH_ONE_COMMENT = 'FETCH_ONE_COMMENT'
 export const DELETE_COMMENT = 'DELETE_COMMENT';
 export const UPDATE_COMMENT = 'UPDATE_COMMENT';
 export const SEARCH = 'SEARCH';

--- a/src/assets/scss/modal.scss
+++ b/src/assets/scss/modal.scss
@@ -54,8 +54,7 @@
 }
 
 .wrap-follow-model {
-  display: flex;
-  align-items: center;
+  display: flex;align-items: center;
   justify-content: center;
   position: fixed;
   top: 0;
@@ -108,3 +107,57 @@
     }
   }
 }
+.wrap-edit-history-model {
+  display: flex;
+  z-index: 4;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: rgba(0, 0, 0, 0.3);
+  
+  .edit-history-model {
+    background-color: teal;
+    border-radius: 5px;
+    color: white;
+    width: 500px;
+    min-height: 400px;
+    margin: 0 auto;
+    padding: 8px;
+
+    .edit-history-model-menu {
+      width: 100%;
+      height: 50px;
+      border-bottom: 1px solid rgba(255,255,255, 0.404);
+      box-shadow: 0px 1px 0px rgba(255,255,255, 0.404);
+      strong {
+        position: relative;
+        top: 15px;
+        left: 25%;
+        font-size: 21px;
+      }
+      img {
+        float: right;
+      }
+    }
+
+      .comment-list {
+        margin-top: 8%;
+        ul {
+          list-style-type: none;
+          border-bottom: 1px solid rgba(255,255,255, 0.404);
+          #body {
+            font-size: 1em;
+          }
+          #time {
+            font-size: 0.8em;
+            padding-bottom: 2%;
+          }
+        }
+      }
+    }
+  }
+

--- a/src/components/articles/createOrUpdateArticle.jsx
+++ b/src/components/articles/createOrUpdateArticle.jsx
@@ -4,8 +4,8 @@ import { Fragment } from 'react';
 import { PropTypes } from 'prop-types';
 import Input from '../common/input';
 import Button from '../common/button';
+import Loader from '../common/loader';
 import NavBar from '../common/navBar';
-import { Loader } from '../common/loader'
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 import Notify from '../../helpers/helpers';

--- a/src/components/articles/oneStory.jsx
+++ b/src/components/articles/oneStory.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component , Fragment} from 'react';
 import { connect } from 'react-redux';
 import { PropTypes } from 'prop-types';
 import { ToastContainer } from 'react-toastify';
@@ -10,7 +10,7 @@ import { Tags } from '../common/tag';
 import Moment from 'react-moment';
 import WriteComment from '../comment/writeComment';
 import ReadComment from '../comment/readComment';
-import { fetchComment, deleteComment } from '../../actions/comment';
+import { fetchComment, deleteComment, fetchOneComment } from '../../actions/comment';
 import Helpers from '../../helpers/helpers';
 import LikeAndDislike from './likeAndDislike';
 import { rateArticle, getAllRates } from '../../actions/article/ratingAction';
@@ -20,6 +20,7 @@ import Bookmark from './bookmark';
 import { bookmarkArticle, fetchBookmarks } from '../../actions/bookmarkAction';
 import { isBookmarking } from '../../helpers/bookmarkHelper';
 
+import  CommentEditHistory  from '../comment/editHistory'
 import {
   getLikeAndDislikeCount,
   likeArticle,
@@ -41,8 +42,19 @@ export class OneStory extends Component {
       allRates: []
     },
     disable: true,
-    isAuthanticated: false
+    isAuthanticated: false,
+    editHistory: false,
+    commentId: '',
+    commentSlug: ''
   };
+  toggleModal = (id, slug) => {
+    this.setState({
+        commentSlug: slug,
+        editHistory: !this.state.editHistory,
+        commentId: id,
+    });
+    return slug && id && this.props.fetchOneComment(slug, id);
+  }
   componentDidMount() {
     const {
       match: {
@@ -62,6 +74,9 @@ export class OneStory extends Component {
     const paginate = `limit=${limit}&offset=${offset}`;
     this.props.getAllRates(slug, paginate);
   }
+
+  displayComments = () => {
+  };
 
   componentDidUpdate(prevProps) {
     const { isCommentFetched } = this.props.state.comment;
@@ -183,12 +198,15 @@ export class OneStory extends Component {
   render() {
     const { bookmark, article } = this.props.state;
     let isBookmark = isBookmarking(bookmark, article.article.title);
+    const { isBookmarked } = this.props.state.bookmark;
+    const { editHistory, commentId, commentSlug } = this.state;
     const { slug } = this.props.match.params;
     const { comments, rate, rates } = this.state;
     const data = this.props.state.article.article;
-    const { isBookmarked } = this.props.state.bookmark;
     if (this.props.state.article.fetched === 'done') {
       return (
+      <Fragment>
+      <CommentEditHistory display={editHistory} onClose={this.toggleModal} id={commentId} slug={commentSlug} />
         <div id='component-oneStory'>
           <NavBar />
           {localStorage.token === undefined ? '' : <ToastContainer />}
@@ -250,6 +268,8 @@ export class OneStory extends Component {
                           onDelete={() => {
                             this.handleDelete(comment.id, slug);
                           }}
+                          articleSlug={slug}
+                          onOpenModal={this.toggleModal}
                         />
                       );
                     })}
@@ -257,6 +277,7 @@ export class OneStory extends Component {
             </div>
           </div>
         </div>
+        </Fragment>
       );
     } else {
       return (
@@ -301,6 +322,7 @@ export default connect(
     rateArticle,
     getAllRates,
     fetchBookmarks,
-    bookmarkArticle
+    bookmarkArticle,
+    fetchOneComment
   }
 )(OneStory);

--- a/src/components/comment/editHistory.jsx
+++ b/src/components/comment/editHistory.jsx
@@ -1,0 +1,67 @@
+import React, { Component } from 'react';
+import {connect} from 'react-redux';
+import PropTypes from 'prop-types';
+import Moment from 'react-moment';
+import closeImage from '../../assets/images/close.png';
+
+ export class CommentEditHistory extends Component {
+   state = {
+     comments: []
+   };
+
+   componentWillReceiveProps(nextProps) {
+      const { state} = nextProps;
+      this.updateCommentHistory(state.comment);
+   }
+
+   updateCommentHistory(comment) {
+     return comment.history && this.setState(prevState => ({
+      ...prevState,
+      comments: comment.history
+    }))
+   }
+
+    render() { 
+      const {comments} = this.state;
+      const { display, onClose } = this.props;
+      if(!display) {return null} else{
+     return ( 
+      <div className='wrap-edit-history-model'>
+      <div className='edit-history-model'>
+        <div className='edit-history-model-menu'>
+          <strong>Comment Edit History</strong>
+          <img
+            src={closeImage}
+            onClick={onClose}
+            style={{ cursor: 'pointer' }}
+          />
+          <div className='comment-list'>
+            {comments.map((comment, key) => {
+              return (
+                <ul key={key}>
+                  <li id='body'>{comment.body}</li>
+                  <li id='time'><Moment fromNow ago>{comment.createdAt}</Moment></li>
+                </ul>
+              )
+            } )}
+          </div>
+        </div>
+      </div>
+    </div>
+
+      );}
+   }
+ }
+ const mapStateToProps = state => {
+  return { state };
+};
+CommentEditHistory.propTypes = {
+  updateComment: PropTypes.func,
+  onClose: PropTypes.func,
+  display: PropTypes.func,
+  comment:PropTypes.object,
+  history:PropTypes.object,
+  state:PropTypes.object
+};
+
+export default connect( mapStateToProps )(CommentEditHistory);

--- a/src/components/comment/readComment.jsx
+++ b/src/components/comment/readComment.jsx
@@ -10,6 +10,8 @@ import Delete from '../../assets/images/delete.png';
 import Update from '../../assets/images/update.png';
 import LikeComment from '../comment/likeComment';
 import Helpers from '../../helpers/helpers';
+import like from '../../assets/images/thumbs-up-hand-symbol.png';
+import Button from '../common/button'
 class ReadComment extends Component {
   state = {
     updatedComment: this.props.comment.body,
@@ -48,7 +50,7 @@ class ReadComment extends Component {
     }
   }
   render() {
-    const { comment, onDelete, auth } = this.props;
+    const { comment, onDelete, auth, articleSlug  } = this.props;
     let id = comment.createdAt;
     return (
       <div className='overlap'>
@@ -86,6 +88,8 @@ class ReadComment extends Component {
           />
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
           <Moment fromNow>{comment.createdAt}</Moment>
+          {(comment.histories) ? <Button value="View edit history" className="edit-history" onClick={() => this.props.onOpenModal(comment.id, articleSlug)}/> : ''}
+
         </div>
         <div className='comment' id={id} style={{ display: 'none' }}>
           <p className='name'>
@@ -133,7 +137,9 @@ ReadComment.propTypes = {
   updateComment: PropTypes.func,
   likeArticleComment: PropTypes.func,
   getLikeArticleComment: PropTypes.func,
-  likeComment: PropTypes.object
+  likeComment: PropTypes.object,
+  onOpenModal: PropTypes.func,
+  articleSlug:PropTypes.string
 };
 
 export default connect(

--- a/src/reducers/commentReducer.js
+++ b/src/reducers/commentReducer.js
@@ -3,7 +3,8 @@ import {
   CREATE_COMMENT,
   FETCH_COMMENT,
   DELETE_COMMENT,
-  UPDATE_COMMENT
+  UPDATE_COMMENT,
+  FETCH_ONE_COMMENT
 } from '../actions/types';
 import { pending, fulfilled } from '../utils/actionUtil';
 
@@ -79,6 +80,12 @@ const commentReducer = (state = initialState, action) => {
         isCommentUpdated: 'done',
         comments: [...action.payload.data.comments]
       };
+      case fulfilled( FETCH_ONE_COMMENT ):
+      return {
+        ...state,
+        isCommentFetched: 'done',
+        history: action.payload.data.comment.histories.rows
+      }
     default:
       return state;
   }

--- a/src/tests/components/comment/editHistory.test.js
+++ b/src/tests/components/comment/editHistory.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { CommentEditHistory } from '../../../components/comment/editHistory'
+
+const props = {
+    onClose: jest.fn(),
+    display: jest.fn(),
+    state:{comment:{history:[{body:'hhh', createdAt: new Date()}]}}
+}
+
+test('editHistory Component', () => {
+    const checkeditHistory = shallow(<CommentEditHistory {...props} />);
+    checkeditHistory.setProps(props);
+});


### PR DESCRIPTION
#### Description
This PR is for tracking comment edit history functionalities.

#### Type of change
N/A

#### How has it been tested
By going to `http://localhost:3002/articles/:slug` and edit a comment, that same comment will show a button. Then if you click that button, it will bring a pop up with the history of the comment and the time of every edit.

#### Pivotal tracker story ID
#165413084

#### Screenshots
<img width="877" alt="Screen Shot 2019-07-31 at 10 20 15" src="https://user-images.githubusercontent.com/33568373/62196761-e3c37700-b37e-11e9-81a6-d14920e1bf4d.png">
